### PR TITLE
Remove text field from the linter messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,6 @@ function linter() {
     function transform(message) {
         return {
           'type': 'Error',
-          'text': message.reason,
           'html': toHTML(message.reason),
           'filePath': this.getPath(),
           'range': toRange(message.location)


### PR DESCRIPTION
Linter does not support both `html` and `text`, and on the latest version this will cause an error to be thrown.

Closes #9
